### PR TITLE
Use OrderedDict conversion output for response

### DIFF
--- a/harvest/harvest.py
+++ b/harvest/harvest.py
@@ -3,6 +3,7 @@ import requests
 from requests_oauthlib import OAuth2Session
 from urllib.parse import urlparse
 from base64 import b64encode
+from collections import OrderedDict
 
 HARVEST_STATUS_URL = "http://www.harveststatus.com/api/v2/status.json"
 
@@ -343,7 +344,7 @@ class HarvestUser:
             resp = requestor.request(**kwargs)
             if "DELETE" not in method:
                 try:
-                    return resp.json()
+                    return resp.json(object_pairs_hook=OrderedDict)
                 except:
                     return resp
             return resp


### PR DESCRIPTION
In order to keep order of original JSON response, use OrderedDict for object_pairs_hook parameter in requests response JSON conversion.

Otherwise, plain dict will be used, and the order of dict keys is not guaranteed (i. e. it's random). This makes impossible to guarantee file format in case we are doing conversion from Harvest to, for example, CSV files and also it makes impossible writing sane test cases for such scenarios.

Reference to data type differences discussion on SO:
http://stackoverflow.com/questions/1867861/python-dictionary-keep-keys-values-in-same-order-as-declared
